### PR TITLE
corrige lógica de adição final de produtos à lista

### DIFF
--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -9,12 +9,12 @@ class List < ApplicationRecord
     name_list = []
     recipes.each do |recipe|
       recipe.recipe_products.each do |recipe_product|
-        item = { name: recipe_product.product.name.to_s, quantity: recipe_product.quantity.to_i, category: recipe_product.product.category }
+        item = { name: recipe_product.product.name.to_s, quantity: (recipe_product.quantity.to_i) * (people / recipe.people), category: recipe_product.product.category }
         if name_list.include?(item[:name])
           temp_array = updated_list.select { |element| element[:name] == item[:name] }
           other_item = temp_array.last
           name = item[:name]
-          quantity = other_item[:quantity] + item[:quantity]
+          quantity = (other_item[:quantity] + item[:quantity])
           category = other_item[:category]
           new_item = { name: name, quantity: quantity, category: category }
           updated_list.delete_at(updated_list.index(other_item))

--- a/spec/system/lists/user_adds_recipes_to_list_spec.rb
+++ b/spec/system/lists/user_adds_recipes_to_list_spec.rb
@@ -43,18 +43,18 @@ describe 'Usuário adiciona receitas à lista de compras' do
     expect(page).to have_css 'h4', text: category2.name
     expect(page).to have_css 'h4', text: category3.name
     within("ul.#{category.name.gsub(' ', '')}") do
-      expect(page).to have_content("1 x #{product.name}")
-      expect(page).to have_content("3 x #{product2.name}")
-      expect(page).to have_content("1 x #{product3.name}")
-      expect(page).to have_content("1 x #{product4.name}")
-      expect(page).to have_content("1 x #{product5.name}")
+      expect(page).to have_content("2 x #{product.name}")
+      expect(page).to have_content("6 x #{product2.name}")
+      expect(page).to have_content("2 x #{product3.name}")
+      expect(page).to have_content("2 x #{product4.name}")
+      expect(page).to have_content("2 x #{product5.name}")
     end
     within("ul.#{category2.name.gsub(' ', '')}") do
-      expect(page).to have_content("1 x #{product6.name}")
-      expect(page).to have_content("1 x #{product7.name}")
+      expect(page).to have_content("2 x #{product6.name}")
+      expect(page).to have_content("2 x #{product7.name}")
     end
     within("ul.#{category3.name.gsub(' ', '')}") do
-      expect(page).to have_content("1 x #{product8.name}")
+      expect(page).to have_content("2 x #{product8.name}")
     end
   end
 end


### PR DESCRIPTION
Lista final de produtos leva em consideração a quantidade de pessoas que serve cada receita e a quantidade de pessoas para a qual a compra está sendo feita. 